### PR TITLE
Unite type `T` and `*T`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           mv /tmp/linux-amd64 /tmp/gobin
           chmod +x /tmp/gobin
           /tmp/gobin honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION
+          /tmp/gobin github.com/securego/gosec/cmd/gosec
         env:
           GOBIN_VERSION: 'v0.0.11'
           STATICCHECK_VERSION: '2020.1.4'
@@ -108,3 +109,4 @@ jobs:
         run: |
           go vet -v -all ./...
           /home/runner/go/bin/staticcheck -tests -show-ignored -go 1.14 -unused.whole-program ./...
+          gosec ./...

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/komuw/dir
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.1
 	github.com/pkg/errors v0.9.1
 	golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 
 // TODO: clean up
 
+// TODO: fuzz test
+
 // TODO: add documentation for `dir`
 
 // TODO: add a command line api.

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ import (
   https://github.com/sanity-io/litter/blob/b3546bd0a12c8738436e565b9e016bcd1876403d/LICENSE
 */
 
-const acceptableCodeCoverage = 0.6 // 60%
+const acceptableCodeCoverage = 0.5 // 60%
 
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ import (
   https://github.com/sanity-io/litter/blob/b3546bd0a12c8738436e565b9e016bcd1876403d/LICENSE
 */
 
-const acceptableCodeCoverage = 0.5 // 60%
+const acceptableCodeCoverage = 0.6 // 60%
 
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags

--- a/panic_handler.go
+++ b/panic_handler.go
@@ -8,6 +8,9 @@ import "fmt"
 // 	defer panicHandler()
 // }
 //
+// Do note that this would not catch all panics.
+// eg; `panic(nil)` will not be caught
+//
 func panicHandler() {
 	// keep an eye on the accepeted proposal: issues/37023
 	// https://github.com/golang/go/issues/37023

--- a/panic_handler.go
+++ b/panic_handler.go
@@ -2,6 +2,8 @@ package main
 
 import "fmt"
 
+// TODO: remove this file
+
 // Usage:
 //
 // func main() {

--- a/vars.go
+++ b/vars.go
@@ -65,8 +65,10 @@ func newVari(i interface{}) vari {
 	var methods = trimMethods(getAllMethods(i))
 
 	return vari{
-		Name:      typeName,
-		Kind:      typeKind,
+		Name: typeName,
+		// TODO: the kind of `*T` should not be displayed as `ptr`
+		Kind: typeKind,
+		// TODO: for type `T`, signature should be both `T` and `*T`
 		Signature: typeSig,
 		Fields:    fields,
 		Methods:   methods,

--- a/vars.go
+++ b/vars.go
@@ -138,6 +138,7 @@ func getAllMethods(i interface{}) []string {
 	allMethods = append(allMethods, methodsOfT...)
 	allMethods = append(allMethods, methodsOfPointerT...)
 	allMethods = append(allMethods, methodsOfPassedInType...)
+
 	return allMethods
 }
 
@@ -168,7 +169,7 @@ func getMethods(iType reflect.Type) []string {
 // trimMethods removes any duplicated methods.
 // if a method is applicable for both type `T` and `*T`, then `trimMethods` will
 // just remove the one for `*T`
-func trimMethods(methods []string) (trimmedMethods []string) {
+func trimMethods(methods []string) []string {
 
 	// contains tells whether a contains x.
 	contains := func(a []string, x string) bool {
@@ -180,6 +181,7 @@ func trimMethods(methods []string) (trimmedMethods []string) {
 		return false
 	}
 
+	var trimmedMethods = []string{}
 	var TmethNames []string
 
 	// first add all methods for type `T`

--- a/vars.go
+++ b/vars.go
@@ -60,7 +60,22 @@ func newVari(i interface{}) vari {
 		}
 	}
 
+	var fields = getFields(iType)
+	var methods = getMethods(iType)
+
+	return vari{
+		Name:      typeName,
+		Kind:      typeKind,
+		Signature: typeSig,
+		Fields:    fields,
+		Methods:   methods,
+	}
+
+}
+
+func getFields(iType reflect.Type) []string {
 	var fields = []string{}
+	typeKind := iType.Kind()
 	if typeKind == reflect.Struct {
 		numFields := iType.NumField()
 		for i := 0; i < numFields; i++ {
@@ -73,6 +88,10 @@ func newVari(i interface{}) vari {
 		}
 	}
 
+	return fields
+}
+
+func getMethods(iType reflect.Type) []string {
 	var methods = []string{}
 	numMethods := iType.NumMethod()
 	for i := 0; i < numMethods; i++ {
@@ -92,12 +111,5 @@ func newVari(i interface{}) vari {
 		methods = append(methods, methName+" "+methSig)
 	}
 
-	return vari{
-		Name:      typeName,
-		Kind:      typeKind,
-		Signature: typeSig,
-		Fields:    fields,
-		Methods:   methods,
-	}
-
+	return methods
 }

--- a/vars.go
+++ b/vars.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 )
 
-
 // TODO: merge methods/fields of T and *T
 // 1. https://play.golang.org/p/aQbEhI8WDP0
 // 2. https://play.golang.org/p/EBhZW6hjb7O
@@ -15,11 +14,11 @@ import (
 
 // vari represents a variable
 type vari struct {
-	name      string
-	kind      reflect.Kind
-	signature string
-	fields    []string
-	methods   []string
+	Name      string
+	Kind      reflect.Kind
+	Signature string
+	Fields    []string
+	Methods   []string
 }
 
 func (v vari) String() string {
@@ -33,11 +32,11 @@ FIELDS: %v
 METHODS: %v
 ]
 `,
-		v.name,
-		v.kind,
-		v.signature,
-		v.fields,
-		v.methods,
+		v.Name,
+		v.Kind,
+		v.Signature,
+		v.Fields,
+		v.Methods,
 	)
 }
 
@@ -46,9 +45,9 @@ func newVari(i interface{}) vari {
 	if iType == nil {
 		// TODO: maybe there is a way in reflect to diffrentiate the various types of nil
 		return vari{
-			name:      "nil",
-			kind:      reflect.Ptr,
-			signature: "nil"}
+			Name:      "nil",
+			Kind:      reflect.Ptr,
+			Signature: "nil"}
 	}
 
 	typeKind := iType.Kind()
@@ -70,7 +69,7 @@ func newVari(i interface{}) vari {
 				// private field
 				continue
 			}
-			fields = append(fields, f.PkgPath+"."+f.Name+",")
+			fields = append(fields, f.Name)
 		}
 	}
 
@@ -82,7 +81,7 @@ func newVari(i interface{}) vari {
 			// private method
 			continue
 		}
-		methName := meth.PkgPath + "." + meth.Name
+		methName := meth.Name
 		methSig := meth.Type.String() // type signature
 
 		// TODO: maybe we should try and also add argument names if any.
@@ -90,16 +89,15 @@ func newVari(i interface{}) vari {
 		//   func(main.Foo, int, int) int
 		// it would be cooler to display as;
 		//   func(main.Foo, price int, commission int) int
-		methods = append(methods, "\n\t"+methName+fmt.Sprintf("\n\t\t%v", methSig))
+		methods = append(methods, methName+" "+methSig)
 	}
-	methods = append(methods, "\n\t")
 
 	return vari{
-		name:      typeName,
-		kind:      typeKind,
-		signature: typeSig,
-		fields:    fields,
-		methods:   methods,
+		Name:      typeName,
+		Kind:      typeKind,
+		Signature: typeSig,
+		Fields:    fields,
+		Methods:   methods,
 	}
 
 }

--- a/vars.go
+++ b/vars.go
@@ -60,6 +60,7 @@ func newVari(i interface{}) vari {
 		}
 	}
 
+	// TODO: merge all fields of both type `T` and `*T`
 	var fields = getFields(iType)
 
 	// TODO: If there is a method whose name is reported for both type `T` and `*T` we should only chose the method for `T`

--- a/vars.go
+++ b/vars.go
@@ -61,10 +61,7 @@ func newVari(i interface{}) vari {
 		}
 	}
 
-	// TODO: merge all fields of both type `T` and `*T`
 	var fields = getAllFields(i)
-
-	// TODO: If there is a method whose name is reported for both type `T` and `*T` we should only chose the method for `T`
 	var methods = trimMethods(getAllMethods(i))
 
 	return vari{

--- a/vars.go
+++ b/vars.go
@@ -51,7 +51,7 @@ func newVari(i interface{}) vari {
 			Signature: "nil"}
 	}
 
-	typeKind := iType.Kind()
+	typeKind := getKind(i)
 	typeName := iType.PkgPath() + "." + iType.Name()
 	typeSig := iType.String()
 	if typeName == "." {
@@ -66,7 +66,6 @@ func newVari(i interface{}) vari {
 
 	return vari{
 		Name: typeName,
-		// TODO: the kind of `*T` should not be displayed as `ptr`
 		Kind: typeKind,
 		// TODO: for type `T`, signature should be both `T` and `*T`
 		Signature: typeSig,
@@ -74,6 +73,21 @@ func newVari(i interface{}) vari {
 		Methods:   methods,
 	}
 
+}
+
+func getKind(i interface{}) reflect.Kind {
+	iType := reflect.TypeOf(i)
+	typeKind := iType.Kind()
+
+	if typeKind != reflect.Ptr {
+		return typeKind
+	} else {
+		// the passed in type maybe be a `*T` so lets find the kind of `T`
+		valueI := reflect.ValueOf(i).Elem()
+		iType := valueI.Type()
+		typeKind := iType.Kind()
+		return typeKind
+	}
 }
 
 // getFields finds all the fields(if any) of type `T` and `*T`

--- a/vars_test.go
+++ b/vars_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Person struct {
-	Name   string
-	Age    int
-	Height float32
+	Name             string
+	Age              int
+	Height           float32
+	somePrivateField string
 }
 
 func (p Person) ValueMethodOne() {}

--- a/vars_test.go
+++ b/vars_test.go
@@ -49,7 +49,7 @@ func TestBasicVariables(t *testing.T) {
 
 			&Person{Name: "Jane"}, vari{
 				Name:      ".Person",
-				Kind:      reflect.Ptr,
+				Kind:      reflect.Struct,
 				Signature: "*main.Person",
 				Fields:    []string{"Name", "Age", "Height"},
 				Methods:   []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32"},

--- a/vars_test.go
+++ b/vars_test.go
@@ -24,6 +24,8 @@ func ThisFunction(arg1 string, arg2 int) (string, error) {
 	return "", nil
 }
 
+var thisFunctionVar = ThisFunction
+
 func TestBasicVariables(t *testing.T) {
 	tt := []struct {
 		variable interface{}
@@ -52,6 +54,15 @@ func TestBasicVariables(t *testing.T) {
 		},
 		{
 			ThisFunction, vari{
+				Name:      "github.com/komuw/dir.ThisFunction",
+				Kind:      reflect.Func,
+				Signature: "func(string, int) (string, error)",
+				Fields:    []string{},
+				Methods:   []string{},
+			},
+		},
+		{
+			thisFunctionVar, vari{
 				Name:      "github.com/komuw/dir.ThisFunction",
 				Kind:      reflect.Func,
 				Signature: "func(string, int) (string, error)",

--- a/vars_test.go
+++ b/vars_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type Person struct {
+	Name   string
+	Age    int
+	Height float32
+}
+
+func (p Person) ValueMethodOne() {}
+func (p *Person) PtrMethodOne()  {}
+func (p Person) ValueMethodTwo() {}
+
+func TestVariables(t *testing.T) {
+	tt := []struct {
+		variable interface{}
+		expected vari
+	}{
+		{
+			Person{Name: "John"}, vari{
+				Name:      "github.com/komuw/dir.Person",
+				Kind:      reflect.Struct,
+				Signature: "main.Person",
+				Fields:    []string{"Name", "Age", "Height"},
+				// TODO: `Methods` should include `PtrMethodOne`
+				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)"},
+			},
+		},
+	}
+
+	for _, v := range tt {
+		res := newVari(v.variable)
+
+		if !cmp.Equal(res, v.expected) {
+			t.Errorf("\ngot %#+v \nwanted %#+v", res, v.expected)
+		}
+	}
+}

--- a/vars_test.go
+++ b/vars_test.go
@@ -52,7 +52,7 @@ func TestBasicVariables(t *testing.T) {
 				Name:      ".Person",
 				Kind:      reflect.Ptr,
 				Signature: "*main.Person",
-				Fields:    []string{},
+				Fields:    []string{"Name", "Age", "Height"},
 				// TODO: `Methods` should be unified with that of Person{} above
 				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
 			},

--- a/vars_test.go
+++ b/vars_test.go
@@ -19,6 +19,7 @@ func (p *Person) somePrivateMethodTwo() {}
 func (p Person) ValueMethodOne()        {}
 func (p *Person) PtrMethodOne()         {}
 func (p Person) ValueMethodTwo()        {}
+func (p *Person) PtrMethodTwo() float32 { return p.Height }
 
 func ThisFunction(arg1 string, arg2 int) (string, error) {
 	return "", nil
@@ -42,7 +43,7 @@ func TestBasicVariables(t *testing.T) {
 				Signature: "main.Person",
 				Fields:    []string{"Name", "Age", "Height"},
 				// TODO: `Methods` should include `PtrMethodOne`
-				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)"},
+				Methods: []string{"PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)", "ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)"},
 			},
 		},
 		{
@@ -53,7 +54,7 @@ func TestBasicVariables(t *testing.T) {
 				Signature: "*main.Person",
 				Fields:    []string{},
 				// TODO: `Methods` should be unified with that of Person{} above
-				Methods: []string{"PtrMethodOne func(*main.Person)", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
+				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
 			},
 		},
 		{
@@ -80,7 +81,9 @@ func TestBasicVariables(t *testing.T) {
 				Kind:      reflect.Uint16,
 				Signature: "main.customerID",
 				Fields:    []string{},
-				Methods:   []string{"Id func(main.customerID) uint16"},
+				// TODO: this should only be `Id func(main.customerID) uint16`
+				// If there is a method whose name is reported for both type `T` and `*T` we should only chose the method for `T`
+				Methods: []string{"Id func(*main.customerID) uint16", "Id func(main.customerID) uint16"},
 			},
 		},
 	}

--- a/vars_test.go
+++ b/vars_test.go
@@ -42,8 +42,7 @@ func TestBasicVariables(t *testing.T) {
 				Kind:      reflect.Struct,
 				Signature: "main.Person",
 				Fields:    []string{"Name", "Age", "Height"},
-				// TODO: `Methods` should include `PtrMethodOne`
-				Methods: []string{"PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)", "ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)"},
+				Methods:   []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32"},
 			},
 		},
 		{
@@ -53,8 +52,7 @@ func TestBasicVariables(t *testing.T) {
 				Kind:      reflect.Ptr,
 				Signature: "*main.Person",
 				Fields:    []string{"Name", "Age", "Height"},
-				// TODO: `Methods` should be unified with that of Person{} above
-				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
+				Methods:   []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32"},
 			},
 		},
 		{
@@ -83,7 +81,7 @@ func TestBasicVariables(t *testing.T) {
 				Fields:    []string{},
 				// TODO: this should only be `Id func(main.customerID) uint16`
 				// If there is a method whose name is reported for both type `T` and `*T` we should only chose the method for `T`
-				Methods: []string{"Id func(*main.customerID) uint16", "Id func(main.customerID) uint16"},
+				Methods: []string{"Id func(main.customerID) uint16"},
 			},
 		},
 	}
@@ -92,7 +90,7 @@ func TestBasicVariables(t *testing.T) {
 		res := newVari(v.variable)
 
 		if !cmp.Equal(res, v.expected) {
-			t.Errorf("\ngot %#+v \nwanted %#+v", res, v.expected)
+			t.Errorf("\ngot \n\t%#+v \nwanted \n\t%#+v", res, v.expected)
 		}
 	}
 }

--- a/vars_test.go
+++ b/vars_test.go
@@ -26,6 +26,10 @@ func ThisFunction(arg1 string, arg2 int) (string, error) {
 
 var thisFunctionVar = ThisFunction
 
+type customerID uint16
+
+func (c customerID) Id() uint16 { return uint16(c) }
+
 func TestBasicVariables(t *testing.T) {
 	tt := []struct {
 		variable interface{}
@@ -68,6 +72,15 @@ func TestBasicVariables(t *testing.T) {
 				Signature: "func(string, int) (string, error)",
 				Fields:    []string{},
 				Methods:   []string{},
+			},
+		},
+		{
+			customerID(9), vari{
+				Name:      "github.com/komuw/dir.customerID",
+				Kind:      reflect.Uint16,
+				Signature: "main.customerID",
+				Fields:    []string{},
+				Methods:   []string{"Id func(main.customerID) uint16"},
 			},
 		},
 	}

--- a/vars_test.go
+++ b/vars_test.go
@@ -32,6 +32,17 @@ func TestVariables(t *testing.T) {
 				Methods: []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)"},
 			},
 		},
+		{
+
+			&Person{Name: "Jane"}, vari{
+				Name:      ".Person",
+				Kind:      reflect.Ptr,
+				Signature: "*main.Person",
+				Fields:    []string{},
+				// TODO: `Methods` should be unified with that of Person{} above
+				Methods: []string{"PtrMethodOne func(*main.Person)", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
+			},
+		},
 	}
 
 	for _, v := range tt {

--- a/vars_test.go
+++ b/vars_test.go
@@ -40,7 +40,7 @@ func TestBasicVariables(t *testing.T) {
 			Person{Name: "John"}, vari{
 				Name:      "github.com/komuw/dir.Person",
 				Kind:      reflect.Struct,
-				Signature: "main.Person",
+				Signature: []string{"main.Person", "*main.Person"},
 				Fields:    []string{"Name", "Age", "Height"},
 				Methods:   []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32"},
 			},
@@ -50,7 +50,7 @@ func TestBasicVariables(t *testing.T) {
 			&Person{Name: "Jane"}, vari{
 				Name:      ".Person",
 				Kind:      reflect.Struct,
-				Signature: "*main.Person",
+				Signature: []string{"*main.Person", "main.Person"},
 				Fields:    []string{"Name", "Age", "Height"},
 				Methods:   []string{"ValueMethodOne func(main.Person)", "ValueMethodTwo func(main.Person)", "PtrMethodOne func(*main.Person)", "PtrMethodTwo func(*main.Person) float32"},
 			},
@@ -59,7 +59,7 @@ func TestBasicVariables(t *testing.T) {
 			ThisFunction, vari{
 				Name:      "github.com/komuw/dir.ThisFunction",
 				Kind:      reflect.Func,
-				Signature: "func(string, int) (string, error)",
+				Signature: []string{"func(string, int) (string, error)"},
 				Fields:    []string{},
 				Methods:   []string{},
 			},
@@ -68,7 +68,7 @@ func TestBasicVariables(t *testing.T) {
 			thisFunctionVar, vari{
 				Name:      "github.com/komuw/dir.ThisFunction",
 				Kind:      reflect.Func,
-				Signature: "func(string, int) (string, error)",
+				Signature: []string{"func(string, int) (string, error)"},
 				Fields:    []string{},
 				Methods:   []string{},
 			},
@@ -77,7 +77,7 @@ func TestBasicVariables(t *testing.T) {
 			customerID(9), vari{
 				Name:      "github.com/komuw/dir.customerID",
 				Kind:      reflect.Uint16,
-				Signature: "main.customerID",
+				Signature: []string{"main.customerID"},
 				Fields:    []string{},
 				Methods:   []string{"Id func(main.customerID) uint16"},
 			},

--- a/vars_test.go
+++ b/vars_test.go
@@ -14,9 +14,11 @@ type Person struct {
 	somePrivateField string
 }
 
-func (p Person) ValueMethodOne() {}
-func (p *Person) PtrMethodOne()  {}
-func (p Person) ValueMethodTwo() {}
+func (p Person) somePrivateMethodOne()  {}
+func (p *Person) somePrivateMethodTwo() {}
+func (p Person) ValueMethodOne()        {}
+func (p *Person) PtrMethodOne()         {}
+func (p Person) ValueMethodTwo()        {}
 
 func TestVariables(t *testing.T) {
 	tt := []struct {

--- a/vars_test.go
+++ b/vars_test.go
@@ -20,6 +20,10 @@ func (p Person) ValueMethodOne()        {}
 func (p *Person) PtrMethodOne()         {}
 func (p Person) ValueMethodTwo()        {}
 
+func ThisFunction(arg1 string, arg2 int) (string, error) {
+	return "", nil
+}
+
 func TestBasicVariables(t *testing.T) {
 	tt := []struct {
 		variable interface{}
@@ -44,6 +48,15 @@ func TestBasicVariables(t *testing.T) {
 				Fields:    []string{},
 				// TODO: `Methods` should be unified with that of Person{} above
 				Methods: []string{"PtrMethodOne func(*main.Person)", "ValueMethodOne func(*main.Person)", "ValueMethodTwo func(*main.Person)"},
+			},
+		},
+		{
+			ThisFunction, vari{
+				Name:      "github.com/komuw/dir.ThisFunction",
+				Kind:      reflect.Func,
+				Signature: "func(string, int) (string, error)",
+				Fields:    []string{},
+				Methods:   []string{},
 			},
 		},
 	}

--- a/vars_test.go
+++ b/vars_test.go
@@ -20,7 +20,7 @@ func (p Person) ValueMethodOne()        {}
 func (p *Person) PtrMethodOne()         {}
 func (p Person) ValueMethodTwo()        {}
 
-func TestVariables(t *testing.T) {
+func TestBasicVariables(t *testing.T) {
 	tt := []struct {
 		variable interface{}
 		expected vari

--- a/vars_test.go
+++ b/vars_test.go
@@ -79,9 +79,7 @@ func TestBasicVariables(t *testing.T) {
 				Kind:      reflect.Uint16,
 				Signature: "main.customerID",
 				Fields:    []string{},
-				// TODO: this should only be `Id func(main.customerID) uint16`
-				// If there is a method whose name is reported for both type `T` and `*T` we should only chose the method for `T`
-				Methods: []string{"Id func(main.customerID) uint16"},
+				Methods:   []string{"Id func(main.customerID) uint16"},
 			},
 		},
 	}


### PR DESCRIPTION
## What(What have you changed/added/removed?)
- When someone passes in a type `T` show them all the methods of `T` and `*T`; and vice versa

## Why(Why did you change/add/remove it?)
- This tool will(hopefully) mostly be used for debugging, thus when someone is reaching for it; they are mostly interested in knowing the entire type space of `T`
